### PR TITLE
Fix music bot playback issues

### DIFF
--- a/stream/stream.go
+++ b/stream/stream.go
@@ -73,6 +73,10 @@ func (s *StreamingSession) stream() error {
 		s.running = false
 	}()
 
+	// Pace outgoing frames to real time based on the source frame duration
+	pacer := time.NewTicker(s.source.FrameDuration())
+	defer pacer.Stop()
+
 	for {
 
 		if s.paused {
@@ -94,6 +98,8 @@ func (s *StreamingSession) stream() error {
 		}
 
 		s.Unlock()
+		// Wait for the next frame tick to ensure real-time pacing
+		<-pacer.C
 		err := s.readNext()
 		s.Lock()
 		if err != nil {


### PR DESCRIPTION
Add real-time pacing to audio streaming to fix condensed, fast-played music.

---
<a href="https://cursor.com/background-agent?bcId=bc-c1ea6cd5-623d-434b-a23a-49b788a74465">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c1ea6cd5-623d-434b-a23a-49b788a74465">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

