### PR TITLE
Fix bot audio playback

### DIFF
--- a/bot/music.go
+++ b/bot/music.go
@@ -384,6 +384,8 @@ func (b *Bot) downloadVideo(link string) (string, error) {
 		"-i", link,
 		"-map", "0:a",
 		"-acodec", "libopus",
+		"-ar", "48000",
+		"-ac", "2",
 		"-f", "ogg",
 		"-y",
 		filePath,

--- a/bot/play.go
+++ b/bot/play.go
@@ -277,7 +277,7 @@ func (b *Bot) onPlay(s *discordgo.Session, i *discordgo.InteractionCreate) {
 					rawURL = songOk.RequestedDownloads[0].RequestedFormats[1].URL
 				}
 
-				rawURL, err := b.downloadVideo(rawURL)
+				rawURL, err = b.downloadVideo(rawURL)
 				if err != nil {
 					log.Println("Error downloading sound:", err)
 					s.FollowupMessageCreate(i.Interaction, true, &discordgo.WebhookParams{

--- a/dca/decode.go
+++ b/dca/decode.go
@@ -107,7 +107,7 @@ func (d *Decoder) OpusFrame() (frame []byte, err error) {
 // FrameDuration implements OpusReader, returnining the specified duration per frame
 func (d *Decoder) FrameDuration() time.Duration {
 	if d.Metadata == nil {
-		return 20
+		return 20 * time.Millisecond
 	}
 
 	// I don't understand nick, why does it have to be like this nick, please nick, im not having a good time nick.

--- a/dca/encode.go
+++ b/dca/encode.go
@@ -228,6 +228,17 @@ func (e *EncodeSession) run() {
 		args = append(args, "-af", e.options.AudioFilter)
 	}
 
+	// Enforce Discord-friendly opus parameters
+	// If these flags are already present in args, ffmpeg will use the latter occurrence
+	args = append(args,
+		"-vbr", "on",
+		"-compression_level", strconv.Itoa(e.options.CompressionLevel),
+		"-ar", strconv.Itoa(e.options.FrameRate),
+		"-ac", strconv.Itoa(e.options.Channels),
+		"-b:a", strconv.Itoa(e.options.Bitrate*1000),
+		"-application", string(e.options.Application),
+	)
+
 	args = append(args, "pipe:1")
 
 	ffmpeg := exec.Command("ffmpeg", args...)

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -115,6 +115,7 @@ func (s *StreamingSession) stream() error {
 }
 
 func (s *StreamingSession) readNext() error {
+	frameStart := time.Now()
 	opus, err := s.source.OpusFrame()
 	if err != nil {
 		return err
@@ -134,6 +135,13 @@ func (s *StreamingSession) readNext() error {
 	s.Lock()
 	s.framesSent++
 	s.Unlock()
+
+	// Pace sending to Discord's expected frame rate
+	elapsed := time.Since(frameStart)
+	frameDur := s.source.FrameDuration()
+	if frameDur > 0 && elapsed < frameDur {
+		time.Sleep(frameDur - elapsed)
+	}
 
 	return nil
 }


### PR DESCRIPTION
Resolve incorrect bot audio playback by standardizing Opus encoding, correcting frame timing, and adding stream pacing.

---
<a href="https://cursor.com/background-agent?bcId=bc-f55db9bf-8088-4433-b6e2-c2821ad58d48">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f55db9bf-8088-4433-b6e2-c2821ad58d48">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

